### PR TITLE
fix: use platform-specific runtime dir on macOS

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -13,13 +13,9 @@ const (
 )
 
 // Dir returns the session-specific directory path.
-// Uses XDG_RUNTIME_DIR if set, otherwise falls back to /run/user/$UID/dredge/$PPID.
+// The base runtime directory is resolved per-platform by runtimeDir() (see session_*.go).
 func Dir() string {
-	runtime := os.Getenv("XDG_RUNTIME_DIR")
-	if runtime == "" {
-		runtime = fmt.Sprintf("/run/user/%d", os.Getuid())
-	}
-	return filepath.Join(runtime, "dredge", fmt.Sprintf("%d", os.Getppid()))
+	return filepath.Join(runtimeDir(), "dredge", fmt.Sprintf("%d", os.Getppid()))
 }
 
 func ensureDir() error {

--- a/internal/session/session_darwin.go
+++ b/internal/session/session_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// runtimeDir returns the base runtime directory on macOS.
+// Uses XDG_RUNTIME_DIR if set, otherwise falls back to $TMPDIR/dredge-user-$UID
+// (macOS has no /run/user equivalent; $TMPDIR is a per-user temporary directory).
+func runtimeDir() string {
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("dredge-user-%d", os.Getuid()))
+}

--- a/internal/session/session_linux.go
+++ b/internal/session/session_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package session
+
+import (
+	"fmt"
+	"os"
+)
+
+// runtimeDir returns the base runtime directory on Linux.
+// Uses XDG_RUNTIME_DIR if set, otherwise falls back to /run/user/$UID.
+func runtimeDir() string {
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return dir
+	}
+	return fmt.Sprintf("/run/user/%d", os.Getuid())
+}


### PR DESCRIPTION
`dredge` wasn't able to write a temp cache on MacOS.

``` shell
~
❯ dredge ls
Password:
Warning: failed to cache key: failed to create session directory: mkdir /run: read-only file system
No items found. Use 'dredge add' to create one.
```

``` shell
~
❯ dredge add "dredge password in Bitwarden secure note"
Password:
Warning: failed to cache key: failed to create session directory: mkdir /run: read-only file system
Error: failed to create item via editor: failed to create session directory: mkdir /run: read-only file system
```

``` shell
~
❯ mkdir /run
mkdir: /run: Read-only file system
```