### PR TITLE
Skip password prompt and selfheal when showing help

### DIFF
--- a/cmd/dredge/main.go
+++ b/cmd/dredge/main.go
@@ -234,14 +234,17 @@ func main() {
 				}
 			}
 
-			// Run self-healing on new session
-			if isNewSession {
+			// Determine the subcommand (empty string means no args → show help)
+			sub := c.Args().First()
+			isHelpCommand := sub == "" || sub == "help" || sub == "h"
+
+			// Run self-healing on new session (skip for help — no vault access needed)
+			if isNewSession && !isHelpCommand {
 				selfheal.Run()
 			}
 
 			// Ensure a git repo is connected (skip for init/help — those don't need it)
-			sub := c.Args().First()
-			if !devMode && sub != "init" && sub != "help" && sub != "h" && sub != "update" && sub != "up" {
+			if !devMode && !isHelpCommand && sub != "init" && sub != "update" && sub != "up" {
 				if err := commands.EnsureInitialized(); err != nil {
 					return err
 				}


### PR DESCRIPTION
Running `dredge` with no arguments (or `dredge help`/`dredge h`) should display the help message without requiring a password.

Previously, the Before hook would:
1. Run selfheal on every new session — selfheal's Unlink() path calls crypto.GetKeyWithVerification(), which prompts for a password when orphaned links exist.
2. Call EnsureInitialized() for the empty-subcommand case (`dredge` with no args), because the skip-list only covered the literal strings "help" and "h", not the no-args path.

Fix: compute isHelpCommand (sub == "" || sub == "help" || sub == "h") once and use it to gate both selfheal and EnsureInitialized, so neither runs when the user just wants to see help.