### PR TITLE
feat: allow selecting vault directory (vibe coded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ So your entire vault shares the same derived key (this means if you lose your ke
 └── links.json                  ← symlink manifest
 ```
 
+### Vault location
+
+Dredge keeps a pointer to your active vault in an XDG registry file. You can move your vault anywhere and activate it.
+
+Note: this feature was vibe coded.
+
+```bash
+# Persistently set the active vault
+dredge use ~/vaults/personal
+
+# Or override for a single command (does not persist)
+dredge --vault ~/vaults/work ls
+DREDGE_VAULT=~/vaults/work dredge search ssh
+```
+
 So all your encrypted files and `.dredge-key` are stored on the git repo, all the plain text files (the one you decided to make readable by the system) will never be tracked. so do whatever you want wit it. 
 
 ### Session model
@@ -296,6 +311,7 @@ This is _actually_ the reason I built dredge. My SSH config is identical on ever
 | Command | Description | Example |
 |:--------|:------------|:--------|
 | `add` / `a` / `new` / `+` | Add an item (opens editor if no -c flag) | `dredge add "OpenAI Key" -c "sk-..." -t keys` |
+| `use` / `activate` | Set the active vault directory | `dredge use ~/vaults/personal` |
 | `search` / `s` | Search items | `dredge search aws key` |
 | `list` / `ls` | List all items | `dredge ls` |
 | `view` / `v` | View an item | `dredge view xKP` or `dredge 1` |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The spawned file is the only persistent plaintext on disk, and it only exists be
 ### Caveats
 
 - **`--password` flag:** Passing your password inline exposes it in shell history and `ps` output. Avoid it in shared environments.
+- **`DREDGE_PASSWORD` env var:** Environment variables can leak to child processes and may be readable by other processes depending on your OS/config. Prefer the prompt when possible.
 - **Linked items:** A linked item's plaintext lives at the symlink target (e.g. `~/.ssh/config`). It is not git-tracked, but it is on disk in plaintext.
 
 <div align="center">

--- a/cmd/dredge/main.go
+++ b/cmd/dredge/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -36,6 +37,11 @@ func main() {
 				Aliases: []string{"p"},
 				Usage:   "Password for decryption (skips prompt)",
 			},
+			&cli.StringFlag{
+				Name:    "vault",
+				Usage:   "Vault directory to use for this command (does not persist)",
+				EnvVars: []string{"DREDGE_VAULT"},
+			},
 			&cli.BoolFlag{
 				Name:        "debug",
 				Usage:       "Enable debug output",
@@ -59,6 +65,14 @@ func main() {
 			},
 		},
 		Commands: []*cli.Command{
+			{
+				Name:    "use",
+				Aliases: []string{"activate"},
+				Usage:   "Set the active vault directory",
+				Action: func(c *cli.Context) error {
+					return commands.HandleUse(c.Args().Slice())
+				},
+			},
 			{
 				Name:                   "add",
 				Aliases:                []string{"a", "new", "+"},
@@ -238,6 +252,14 @@ func main() {
 		},
 		Before: func(c *cli.Context) error {
 			// Register active vault path — must be first (used by session key scoping and verify file)
+			if vault := strings.TrimSpace(c.String("vault")); vault != "" {
+				if abs, err := resolveUserPath(vault); err == nil {
+					storage.SetVaultOverride(abs)
+					session.SetVaultPath(abs)
+				} else {
+					return err
+				}
+			}
 			if vaultDir, err := storage.GetDredgeDir(); err == nil {
 				session.SetVaultPath(vaultDir)
 			}
@@ -277,7 +299,7 @@ func main() {
 			sub := c.Args().First()
 
 			// Commands that don't need vault access
-			passiveCommands := []string{"", "help", "h", "update", "up", "init", "lock"}
+			passiveCommands := []string{"", "help", "h", "update", "up", "init", "lock", "use", "activate"}
 
 			contains := func(list []string, s string) bool {
 				for _, v := range list {
@@ -342,6 +364,31 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func resolveUserPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+		if p == "~" {
+			p = home
+		} else {
+			p = filepath.Join(home, p[2:])
+		}
+	} else if strings.HasPrefix(p, "~") {
+		return "", fmt.Errorf("unsupported ~ expansion in path: %q", p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", p, err)
+	}
+	return abs, nil
 }
 
 func Debugf(format string, args ...any) {

--- a/cmd/dredge/main.go
+++ b/cmd/dredge/main.go
@@ -36,6 +36,7 @@ func main() {
 				Name:    "password",
 				Aliases: []string{"p"},
 				Usage:   "Password for decryption (skips prompt)",
+				EnvVars: []string{"DREDGE_PASSWORD"},
 			},
 			&cli.StringFlag{
 				Name:    "vault",

--- a/internal/commands/use.go
+++ b/internal/commands/use.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DeprecatedLuar/dredge/internal/crypto"
+	"github.com/DeprecatedLuar/dredge/internal/git"
+	"github.com/DeprecatedLuar/dredge/internal/storage"
+)
+
+// HandleUse activates an existing vault directory and persists it as the active vault.
+// Usage: dredge use <path>
+func HandleUse(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: dredge use <path>")
+	}
+
+	path := strings.TrimSpace(args[0])
+	if path == "" {
+		return fmt.Errorf("usage: dredge use <path>")
+	}
+
+	absPath, err := resolveUserPath(path)
+	if err != nil {
+		return err
+	}
+
+	if !isVaultDir(absPath) {
+		return fmt.Errorf("not a vault directory: %s (expected %s)", absPath, filepath.Join(absPath, "items"))
+	}
+
+	_ = crypto.ClearSession()
+	if err := storage.SetActivePath(absPath); err != nil {
+		return fmt.Errorf("failed to set active vault: %w", err)
+	}
+
+	if url, ok := git.RemoteURL(absPath); ok {
+		fmt.Printf("Activated %s\n", strings.TrimSpace(url))
+	} else {
+		fmt.Printf("Activated %s\n", absPath)
+	}
+
+	return nil
+}
+
+func resolveUserPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+		if p == "~" {
+			p = home
+		} else {
+			p = filepath.Join(home, p[2:])
+		}
+	} else if strings.HasPrefix(p, "~") {
+		return "", fmt.Errorf("unsupported ~ expansion in path: %q", p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", p, err)
+	}
+	return abs, nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -18,6 +19,7 @@ const (
 
 	// Environment variables
 	xdgDataHomeEnv = "XDG_DATA_HOME"
+	vaultDirEnv    = "DREDGE_VAULT"
 
 	// Default paths
 	defaultLocalDir = ".local"
@@ -42,6 +44,52 @@ const (
 	// Gitignore content
 	gitignoreContent = ".spawned/\nlinks.json\n"
 )
+
+var (
+	vaultOverrideMu sync.RWMutex
+	vaultOverride   string
+)
+
+// SetVaultOverride sets a process-local vault directory override.
+// Empty string clears the override.
+func SetVaultOverride(path string) {
+	vaultOverrideMu.Lock()
+	defer vaultOverrideMu.Unlock()
+	vaultOverride = path
+}
+
+func getVaultOverride() string {
+	vaultOverrideMu.RLock()
+	defer vaultOverrideMu.RUnlock()
+	return vaultOverride
+}
+
+// resolvePath expands leading "~/" (or "~") and returns an absolute path.
+// Only supports current-user tilde expansion.
+func resolvePath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", nil
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+		if p == "~" {
+			p = home
+		} else {
+			p = filepath.Join(home, p[2:])
+		}
+	} else if strings.HasPrefix(p, "~") {
+		return "", fmt.Errorf("unsupported ~ expansion in path: %q", p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", p, err)
+	}
+	return abs, nil
+}
 
 // ItemType represents the type of content stored in an item
 type ItemType string
@@ -152,12 +200,20 @@ func SetActivePath(path string) error {
 // GetDredgeDir returns the active vault directory path.
 // If no active vault is set, falls back to the registry directory (backward compat).
 func GetDredgeDir() (string, error) {
+	if ov := getVaultOverride(); strings.TrimSpace(ov) != "" {
+		return resolvePath(ov)
+	}
+
+	if env := os.Getenv(vaultDirEnv); strings.TrimSpace(env) != "" {
+		return resolvePath(env)
+	}
+
 	active, err := GetActivePath()
 	if err != nil {
 		return "", err
 	}
-	if active != "" {
-		return active, nil
+	if strings.TrimSpace(active) != "" {
+		return resolvePath(active)
 	}
 	return GetRegistryDir()
 }
@@ -503,4 +559,3 @@ func ItemExists(id string) (bool, error) {
 	}
 	return false, fmt.Errorf("failed to check item existence: %w", err)
 }
-

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -14,6 +14,7 @@ var testKey = crypto.DeriveKey("test-password-123", []byte("16-byte-salt-val"))
 // setupTestEnv creates a temporary test directory and clears session cache
 func setupTestEnv(t *testing.T) (cleanup func()) {
 	_ = crypto.ClearSession()
+	SetVaultOverride("")
 
 	tmpDir, err := os.MkdirTemp("", "dredge-test-*")
 	if err != nil {
@@ -23,9 +24,17 @@ func setupTestEnv(t *testing.T) (cleanup func()) {
 	// Set XDG_DATA_HOME to temp directory
 	oldXDG := os.Getenv("XDG_DATA_HOME")
 	os.Setenv("XDG_DATA_HOME", tmpDir)
+	oldVault := os.Getenv("DREDGE_VAULT")
+	os.Unsetenv("DREDGE_VAULT")
 
 	return func() {
 		os.Setenv("XDG_DATA_HOME", oldXDG)
+		if oldVault == "" {
+			os.Unsetenv("DREDGE_VAULT")
+		} else {
+			os.Setenv("DREDGE_VAULT", oldVault)
+		}
+		SetVaultOverride("")
 		os.RemoveAll(tmpDir)
 		_ = crypto.ClearSession()
 	}
@@ -44,6 +53,68 @@ func TestGetDredgeDir(t *testing.T) {
 	expected := filepath.Join(tmpDir, "dredge")
 	if dir != expected {
 		t.Errorf("GetDredgeDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestGetDredgeDir_ActivePath(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	tmpDir := os.Getenv("XDG_DATA_HOME")
+	vault := filepath.Join(tmpDir, "my-vault")
+
+	if err := SetActivePath(vault); err != nil {
+		t.Fatalf("SetActivePath failed: %v", err)
+	}
+
+	dir, err := GetDredgeDir()
+	if err != nil {
+		t.Fatalf("GetDredgeDir() failed: %v", err)
+	}
+
+	if dir != vault {
+		t.Errorf("GetDredgeDir() = %q, want %q", dir, vault)
+	}
+}
+
+func TestGetDredgeDir_EnvOverride(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	tmpDir := os.Getenv("XDG_DATA_HOME")
+	vault := filepath.Join(tmpDir, "env-vault")
+	os.Setenv("DREDGE_VAULT", vault)
+
+	dir, err := GetDredgeDir()
+	if err != nil {
+		t.Fatalf("GetDredgeDir() failed: %v", err)
+	}
+	if dir != vault {
+		t.Errorf("GetDredgeDir() = %q, want %q", dir, vault)
+	}
+}
+
+func TestGetDredgeDir_OverridePrecedence(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	tmpDir := os.Getenv("XDG_DATA_HOME")
+	active := filepath.Join(tmpDir, "active-vault")
+	env := filepath.Join(tmpDir, "env-vault")
+	override := filepath.Join(tmpDir, "override-vault")
+
+	if err := SetActivePath(active); err != nil {
+		t.Fatalf("SetActivePath failed: %v", err)
+	}
+	os.Setenv("DREDGE_VAULT", env)
+	SetVaultOverride(override)
+
+	dir, err := GetDredgeDir()
+	if err != nil {
+		t.Fatalf("GetDredgeDir() failed: %v", err)
+	}
+	if dir != override {
+		t.Errorf("GetDredgeDir() = %q, want %q", dir, override)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `dredge use <path>` to persistently switch the active vault directory.
- Add `--vault`/`DREDGE_VAULT` for per-command vault overrides.
- Allow `DREDGE_PASSWORD` env var as an alternative to `--password`.
- Update storage resolution precedence + tests + README.

## Notes
- Marked as vibe coded per request.